### PR TITLE
Add process id as process in import

### DIFF
--- a/docs/invoicing.json
+++ b/docs/invoicing.json
@@ -6,7 +6,7 @@
     "contact": {
       "email": "phoenix-api@it4sport.de"
     },
-    "version": "1.0.8"
+    "version": "1.0.9"
   },
   "servers": [
     {
@@ -316,7 +316,7 @@
           },
           "process": {
             "type": "string",
-            "description": "",
+            "description": "Can be process field from processes API or GUID class 4 id from processes API",
             "example": "BescheidVb"
           },
           "costs": {

--- a/docs/invoicing.yaml
+++ b/docs/invoicing.yaml
@@ -6,7 +6,7 @@ info:
     the api. This parameter will be given with API key.
   contact:
     email: phoenix-api@it4sport.de
-  version: 1.0.8
+  version: 1.0.9
 servers:
   - url: https://{client}.it4sport.de/api/invoicing
 tags:
@@ -218,7 +218,7 @@ components:
           description: is needed to create a new person, if recipientId = 0
         process:
           type: string
-          description: ""
+          description: "Can be process field from processes API or GUID class 4 id from processes API"
           example: BescheidVb
         costs:
           type: number


### PR DESCRIPTION
Um Artikel eindeutig zu identifizieren, soll die API "invoicing/import" als `process ` neben den bekannten Vorgängen, auch eine UUID annehmen können. Die UUID ist die eindeutige ID des Artikels. Die ID wird im Feld `id` bei der API "processes" ebenfalls mitübertragen.
Eine Anpassung der bisherigen Schnittstellenaufrufe ist nicht notwendig, allerdings empfohlen. 
Wenn die ID verwendet wird, ist es nicht notwendig, dass der Artikel einen Vorgang besitzt. Der Vorgang muss lediglich als "im Internet übertragen" in Phoenix II durch die Geschäftsstelle markiert sein.